### PR TITLE
Updating to version 5.0.0

### DIFF
--- a/.abf.yml
+++ b/.abf.yml
@@ -1,3 +1,3 @@
 sources:
-  bcrypt-4.3.0.tar.gz: 8a97628a2def052589e54a2ee211dcb180f0f85e
-  _bcrypt-4.3.0-vendor.tar.xz: 0fb4bbd4554b7aa563069c0a7d68f9dfd51409e5
+  bcrypt-5.0.0.tar.gz:  44f94d38d837b85a3be26b4e5f6c9a3c9c28d668
+  _bcrypt-5.0.0-vendor.tar.xz:  9e034a1635f6fc1c7b15beb3332b26c7b04ef60e

--- a/python-bcrypt.spec
+++ b/python-bcrypt.spec
@@ -11,7 +11,7 @@
 
 Summary:	Modern password hashing for your software and your servers
 Name:		python-bcrypt
-Version:	4.3.0
+Version:	5.0.0
 Release:	1
 # crypt_blowfish code is in Public domain and all other code in Apache 2.0,
 # rust vendor crates mixture of Apache-2.0, MIT, Unlicence -
@@ -20,7 +20,7 @@ License:	Apache-2.0 AND Public Domain AND BSD-3-Clause AND MIT AND (Apache-2.0 O
 Group:		Development/Python
 URL:		https://github.com/pyca/bcrypt
 Source0:	https://pypi.python.org/packages/source/b/%{oname}/%{oname}-%{version}.tar.gz
-Source1:	_bcrypt-4.3.0-vendor.tar.xz
+Source1:	_%{oname}-%{version}-vendor.tar.xz
 
 BuildRequires:  pkgconfig(python)
 BuildRequires:	python%{pyver}dist(pip)


### PR DESCRIPTION
Submitting as PR rather than pushing the update in case we want to wait for base python update to finish.

Updated from version 4.3.0 to 5.0.0